### PR TITLE
Mudando a ordem da sessão "Como Contribuir"

### DIFF
--- a/src/components/HowContribute/HowContribute.js
+++ b/src/components/HowContribute/HowContribute.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+
+import BodyText from '../BodyText';
+import Button from '../Button';
+import styles from './HowContribute.module.scss';
+
+const HowContribute = () => {
+  const router = useRouter();
+
+  return (
+    <section id="colabore" className={styles.contribute}>
+      <img
+        className={styles.contributeImage}
+        src="/assets/people-contribute.svg"
+        alt="Como contribuir"
+      />
+      <div className={styles.contentWrapper}>
+        <h2 className={styles.text}>Como contribuir</h2>
+        <BodyText className={styles.text}>
+          Essa é uma iniciativa voluntária, feita a muitas mãos, e qualquer
+          pessoa interessada pode fazer parte!
+        </BodyText>
+        <Button
+          className={styles.button}
+          onClick={() => router.push('/colabore')}
+        >
+          Veja como contribuir
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default HowContribute;

--- a/src/components/HowContribute/HowContribute.module.scss
+++ b/src/components/HowContribute/HowContribute.module.scss
@@ -1,0 +1,33 @@
+.contribute {
+  display: flex;
+  justify-content: center;
+
+  @media (max-width: 1000px) {
+    flex-direction: column;
+    align-items: center;
+    padding: 4rem 1rem 4rem 1rem;
+  }
+}
+
+.contributeImage {
+  height: 30rem;
+  width: auto;
+  max-width: 90vw;
+  margin-left: 10vw;
+}
+
+.contentWrapper {
+  display: flex;
+  justify-content: space-around;
+  flex-direction: column;
+
+  @media (max-width: 1000px) {
+    margin-top: 2rem;
+    align-items: center;
+  }
+}
+
+.text,
+.button {
+  margin-top: 4rem;
+}

--- a/src/components/HowContribute/HowContrinbute.test.js
+++ b/src/components/HowContribute/HowContrinbute.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { useRouter } from 'next/router';
+
+import HowContribute from './HowContribute';
+
+jest.mock('next/router');
+
+describe('<HowContribute />', () => {
+  it('renders correctly', () => {
+    const { getByText } = render(<HowContribute />);
+    const descriptionText = `Essa é uma iniciativa voluntária, feita a muitas mãos, e qualquer pessoa interessada pode fazer parte!`;
+
+    expect(getByText('Como contribuir')).toBeInTheDocument();
+    expect(getByText(descriptionText)).toBeInTheDocument();
+    expect(getByText('Veja como contribuir')).toBeInTheDocument();
+  });
+
+  describe('behavior', () => {
+    let routerMock;
+    beforeEach(() => {
+      jest.resetAllMocks();
+      routerMock = {
+        push: jest.fn(),
+      };
+
+      useRouter.mockReturnValue(routerMock);
+    });
+
+    it('redirects to the right page when button is clicked by the user', () => {
+      const { getByRole } = render(<HowContribute />);
+      const button = getByRole('button');
+      fireEvent.click(button);
+
+      expect(routerMock.push).toHaveBeenCalledWith('/colabore');
+    });
+  });
+});

--- a/src/components/HowContribute/index.js
+++ b/src/components/HowContribute/index.js
@@ -1,0 +1,1 @@
+export { default } from './HowContribute';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,11 @@
 import { useRouter } from 'next/router';
+
 import SEO from '../components/SEO';
 import Header from '../components/Header';
 import Button from '../components/Button';
 import Link from '../components/Link';
 import VolunteersCard from '../components/VolunteersCard';
+import HowContribute from '../components/HowContribute';
 
 import volunteersList from '../utils/volunteers';
 import styles from './index.module.scss';
@@ -132,19 +134,9 @@ export default function Home() {
         </div>
       </section>
 
-      <section id="colabore" className={styles.contribute}>
-        <img src="/assets/people-contribute.svg" alt="Como contribuir" />
-        <div>
-          <h2>Como contribuir</h2>
-          <BodyText>
-            Essa é uma iniciativa voluntária, feita a muitas mãos, e qualquer
-            pessoa interessada pode fazer parte!
-          </BodyText>
-          <Button onClick={() => router.push('/colabore')}>
-            Veja como contribuir
-          </Button>
-        </div>
-      </section>
+      <div className={styles.contributeWrapper}>
+        <HowContribute />
+      </div>
 
       <section className={styles.bottom}>
         <div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -114,6 +114,10 @@ export default function Home() {
         </div>
       </section>
 
+      <div className={styles.contributeWrapper}>
+        <HowContribute />
+      </div>
+
       <section className={styles.volunteers}>
         <div className={styles.icon}>
           <img src="/assets/icons/hand-with-hearth.svg" alt="Livro" />
@@ -133,10 +137,6 @@ export default function Home() {
           ))}
         </div>
       </section>
-
-      <div className={styles.contributeWrapper}>
-        <HowContribute />
-      </div>
 
       <section className={styles.bottom}>
         <div>

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -141,44 +141,6 @@
   }
 }
 
-.contribute {
-  display: flex;
-  justify-content: center;
-  padding: 4rem;
-
-  img {
-    height: 30rem;
-    width: auto;
-    max-width: 90vw;
-    margin-left: 10vw;
-  }
-
-  div {
-    display: flex;
-    justify-content: space-around;
-    flex-direction: column;
-
-    h5 + p {
-      margin-top: 4rem;
-    }
-
-    p + button {
-      margin-top: 4rem;
-    }
-  }
-
-  @media (max-width: 1000px) {
-    flex-direction: column;
-    align-items: center;
-    padding: 4rem 1rem 4rem 1rem;
-
-    div {
-      margin-top: 2rem;
-      align-items: center;
-    }
-  }
-}
-
 .bottom {
   display: flex;
   flex-direction: column;
@@ -317,4 +279,8 @@
       width: 100%;
     }
   }
+}
+
+.contributeWrapper {
+  padding: 4rem;
 }


### PR DESCRIPTION
Seguindo o [documento](https://docs.google.com/document/d/1Sa3HzzLykC9vox45W7VjmV72iIPvWKLJe3YNM_ZliKA/edit) vi que tinha essa task e aproveitei para refatorar essa sessão:
- [x] - Como contribuir agora vem antes de volutários
- [x] - Criado um componente separado para ela isolando seu js e css
- [x] - Criado arquivos com testes para o componente
- [x] - Removendo o CSS desse componente do arquivo de CSS da página mantendo assim os estilos mais isolados e separados por suas responsabilidades 

Screenshot:
![image](https://user-images.githubusercontent.com/3718366/132131325-e92c252f-35e6-4f9d-be8d-a33c9f4af563.png)
