### PR TITLE
Adição do site de pedidos e modificação de pedidos

### DIFF
--- a/src/utils/volunteers.js
+++ b/src/utils/volunteers.js
@@ -111,7 +111,6 @@ export default [
     linkedin: 'exageraldo',
     twitter: 'exageraldo_',
   },
-  
 ].sort((person1, person2) => {
   return person1.name.localeCompare(person2.name); // Automatically alphabetize
 });


### PR DESCRIPTION
Alteração feita conforme pedido na issue #88.
--> Nome: de Pedidos para Laiá (Pedidos de Informação)
--> Link alterado para: http://pedidos.dadosabertosdefeira.com.br ao invés do repositório do projeto