### PR TITLE
Cores contrastes e acessibilidade

### DIFF
--- a/src/components/Projects/ProjectCard.js
+++ b/src/components/Projects/ProjectCard.js
@@ -36,12 +36,12 @@ const ProjectCard = ({ project }) => {
           </div>
 
           <Link
-            className={`${styles.projectLink} flex items-center`}
+            className={styles.projectLink}
             href={project.link}
             target="_blank"
             rel="noreferrer"
           >
-            <div>
+            <div className="flex items-center">
               Link
               <FiArrowUpRight className={`ml-xs ${styles.projectLinkIcon}`} />
             </div>

--- a/src/components/Tag/Tag.module.scss
+++ b/src/components/Tag/Tag.module.scss
@@ -4,5 +4,5 @@
 }
 
 .text {
-  color: #a8b9c8;
+  color: #656f78;
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,5 +1,5 @@
 // COLORS
-$color-primary: #3793df;
+$color-primary: #2275ba;
 $color-primary--dark: #0063b5;
 $color-text--medium: #163e7a;
 $color-text--dark: #232b4e;


### PR DESCRIPTION
## O que o Pull Request faz?

Muda algumas cores para nosso site ter um melhor contraste e acessibilidade. As cores escolhidas foram tentando o mais próximo da que já existia mas com uma melhor pontuação de contraste usando a ferramenta color.review sugerida na Issue relacionada.

## Por quê o Pull Request foi aberto?

Após os reports do Lighhouse foi visto que algumas das nossas cores em determinados fundos não tinham uma boa acessibilidade em relação ao contraste.

## Screenshots

Nova cor primária na informação do papel dos colaboradores e no link de como contribuir:
<img width="1220" alt="image" src="https://github.com/DadosAbertosDeFeira/portal/assets/3718366/2d1fa69f-56c7-420e-9cbe-3cd6787ce801">
<img width="637" alt="image" src="https://github.com/DadosAbertosDeFeira/portal/assets/3718366/e86d4ac6-4948-4ac1-b333-1d8d478252bb">

Cores novas nas tags dos projetos para aumentar o contraste:
<img width="637" alt="image" src="https://github.com/DadosAbertosDeFeira/portal/assets/3718366/cd96bf21-3ddd-483f-ab26-38aa057068df">


Corrigido Layout quebrado do Link:
<img width="762" alt="image" src="https://github.com/DadosAbertosDeFeira/portal/assets/3718366/e486a406-e324-49a1-ad15-a2f4c9e7454b">



## Notas adicionais

Esse PR também corrige o componente do Link no card dos projetos que estava com o design quebrado.




## Issue relacionada
Closes #9
